### PR TITLE
Add rondas al crear matches y errores personalizados

### DIFF
--- a/src/main/java/com/gamehub/controller/matches/MatchController.java
+++ b/src/main/java/com/gamehub/controller/matches/MatchController.java
@@ -2,6 +2,7 @@ package com.gamehub.controller.matches;
 
 import com.gamehub.dto.match.*;
 import com.gamehub.service.MatchService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -9,11 +10,11 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+@RequestMapping("/matches")
 public class MatchController {
 
-    @Autowired
-    private MatchService matchService;
+    private final MatchService matchService;
 
     @PostMapping("/generate/{tournamentId}")
     public ResponseEntity<Void> generateMatches(@PathVariable UUID tournamentId) {

--- a/src/main/java/com/gamehub/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gamehub/exception/GlobalExceptionHandler.java
@@ -122,6 +122,30 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.FORBIDDEN, ex.getMessage());
     }
 
+    @ExceptionHandler(ResultInvalidException.class)
+    @ApiResponse(
+            responseCode = "400",
+            description = "Se está enviando una entrada incorrecta (un valor inválido para el enum).",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApiErrorResponse.class))
+    )
+    public ResponseEntity<ApiErrorResponse> handlerResultInvalidException(ResultInvalidException ex) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(MatchNotFoundException.class)
+    @ApiResponse(
+            responseCode = "404",
+            description = "Match no encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApiErrorResponse.class))
+    )
+    public ResponseEntity<ApiErrorResponse> handlerMatchNotFoundException(MatchNotFoundException ex) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
     @ExceptionHandler(Exception.class)
     @ApiResponse(
             responseCode = "500",

--- a/src/main/java/com/gamehub/exception/MatchNotFoundException.java
+++ b/src/main/java/com/gamehub/exception/MatchNotFoundException.java
@@ -1,0 +1,5 @@
+package com.gamehub.exception;
+
+public class MatchNotFoundException extends RuntimeException {
+    public MatchNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/gamehub/exception/ResultInvalidException.java
+++ b/src/main/java/com/gamehub/exception/ResultInvalidException.java
@@ -1,0 +1,5 @@
+package com.gamehub.exception;
+
+public class ResultInvalidException extends RuntimeException {
+    public ResultInvalidException(String message) {super(message);}
+}

--- a/src/main/java/com/gamehub/repository/MatchRepository.java
+++ b/src/main/java/com/gamehub/repository/MatchRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 public interface MatchRepository extends JpaRepository<Match, UUID> {
 
     List<Match> findByTournament_Id(UUID tournamentId);
+
+    List<Match> findAllByTournament_Id(UUID tournamentId);
 }

--- a/src/main/java/com/gamehub/service/MatchServiceImpl.java
+++ b/src/main/java/com/gamehub/service/MatchServiceImpl.java
@@ -1,6 +1,8 @@
 package com.gamehub.service;
 
 import com.gamehub.dto.match.*;
+import com.gamehub.exception.MatchNotFoundException;
+import com.gamehub.exception.ResultInvalidException;
 import com.gamehub.model.Match;
 import com.gamehub.model.Result;
 import com.gamehub.model.Tournament;
@@ -8,19 +10,18 @@ import com.gamehub.model.User;
 import com.gamehub.repository.MatchRepository;
 import com.gamehub.repository.TournamentRepository;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
 
 @Service
+@RequiredArgsConstructor
 public class MatchServiceImpl implements MatchService {
 
-    @Autowired
-    private MatchRepository matchRepository;
-
-    @Autowired
-    private TournamentRepository tournamentRepository;
+    private final MatchRepository matchRepository;
+    private final TournamentRepository tournamentRepository;
 
     @Transactional
     @Override
@@ -29,15 +30,29 @@ public class MatchServiceImpl implements MatchService {
                 .orElseThrow(() -> new RuntimeException("Torneo no encontrado"));
 
         List<User> players = tournament.getPlayers();
-        Collections.shuffle(players); 
+        Collections.shuffle(players);
+
+        List<Match> matches = matchRepository.findAllByTournament_Id(tournamentId);
+        int round = 0;
+        if (!matches.isEmpty()) {
+            int maxRound = matches.stream()
+                    .mapToInt(Match::getRound)
+                    .max()
+                    .orElse(round);
+
+            if (maxRound >= round) {
+                round = maxRound + 1;
+            }
+        }
 
         for (int i = 0; i < players.size() - 1; i += 2) {
             Match match = new Match();
             match.setId(UUID.randomUUID());
             match.setPlayer1(players.get(i));
             match.setPlayer2(players.get(i + 1));
+            match.setResult(Result.PENDING);
             match.setTournament(tournament);
-            match.setRound(1); 
+            match.setRound(round);
 
             matchRepository.save(match);
         }
@@ -46,7 +61,7 @@ public class MatchServiceImpl implements MatchService {
     @Override
     public MatchResponseDto getMatchById(UUID id) {
         Match match = matchRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("Partida no encontrada"));
+            .orElseThrow(() -> new MatchNotFoundException("Partida no encontrada"));
 
         MatchResponseDto dto = new MatchResponseDto();
         dto.setId(match.getId());
@@ -58,19 +73,17 @@ public class MatchServiceImpl implements MatchService {
         return dto;
     }
 
-
     @Override
     public void updateMatchResult(UUID id, MatchResultUpdateDto dto) {
         Match match = matchRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Partida no encontrada"));
+                .orElseThrow(() -> new MatchNotFoundException("Partida no encontrada"));
 
         try {
             match.setResult(Result.valueOf(dto.getResult()));
         } catch (IllegalArgumentException e) {
-            throw new RuntimeException("Valor inválido para el resultado: " + dto.getResult());
+            throw new ResultInvalidException("Valor inválido para el resultado: " + dto.getResult() + ". Prueba con: " + Result.PLAYER1_WIN + " o " + Result.PLAYER2_WIN);
         }
 
         matchRepository.save(match);
     }
-
 }


### PR DESCRIPTION
Each time the admin generates a batch of matches for a tournament, a round number is now automatically assigned.
Example: first generation → round 1, second → round 2, and so on.
Created custom exceptions to handle specific cases related to match generation logic.