### PR TITLE
Feature/chat tournament

### DIFF
--- a/src/main/java/com/gamehub/controller/tournament/TournamentsMessagesController.java
+++ b/src/main/java/com/gamehub/controller/tournament/TournamentsMessagesController.java
@@ -1,29 +1,71 @@
 package com.gamehub.controller.tournament;
 
-import com.gamehub.service.MessageServiceImpl;
-import com.gamehub.service.TournamentService;
-import com.gamehub.service.TournamentServiceImpl;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.gamehub.dto.message.MessageDto;
+import com.gamehub.exception.ApiErrorResponse;
+import com.gamehub.service.MessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
-@Controller
+@RestController
 @RequestMapping("/tournaments/{id}/messages")
+@RequiredArgsConstructor
+@Tag(name = "Mensajes del torneo", description = "Endpoints para la gestión de mensajes en torneos")
 public class TournamentsMessagesController {
 
-    //Listar mensajes del torneo
+    private final MessageService messageService;
+
+    @Operation(
+            summary = "Listar mensajes del torneo",
+            description = "Obtiene una lista de mensajes asociados a un torneo específico. Requiere rol de jugador o administrador.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Lista de mensajes obtenida exitosamente",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = MessageDto.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Torneo no encontrado",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiErrorResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "Error interno del servidor",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiErrorResponse.class)
+                            )
+                    )
+            }
+    )
     @GetMapping
     @PreAuthorize("hasAnyRole('PLAYER', 'ADMIN')")
-    public String listTournamentMessages(@PathVariable UUID id) {
+    public ResponseEntity<List<MessageDto>> listTournamentMessages(@PathVariable UUID id) {
 
-        return null;
+        List<MessageDto> messages = messageService.findByTournamentIdMessages(id);
+
+        return ResponseEntity.ok(messages);
     }
 
     //Enviar mensaje al torneo
     @PostMapping
+    @PreAuthorize("hasAnyRole('PLAYER', 'ADMIN')")
     public String sendMessageToTournament(@PathVariable UUID id) {
 
         return null;

--- a/src/main/java/com/gamehub/controller/tournament/TournamentsMessagesController.java
+++ b/src/main/java/com/gamehub/controller/tournament/TournamentsMessagesController.java
@@ -4,6 +4,7 @@ import com.gamehub.service.MessageServiceImpl;
 import com.gamehub.service.TournamentService;
 import com.gamehub.service.TournamentServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +16,7 @@ public class TournamentsMessagesController {
 
     //Listar mensajes del torneo
     @GetMapping
+    @PreAuthorize("hasAnyRole('PLAYER', 'ADMIN')")
     public String listTournamentMessages(@PathVariable UUID id) {
 
         return null;

--- a/src/main/java/com/gamehub/dto/MessageDto.java
+++ b/src/main/java/com/gamehub/dto/MessageDto.java
@@ -1,0 +1,20 @@
+package com.gamehub.dto;
+
+import com.gamehub.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Schema(description = "DTO para mensajes genéricos en la aplicación.")
+public class MessageDto {
+
+    @Schema(description = "Contenido del mensaje", example = "¡Hola, bienvenido a GameHub!")
+    private String content;
+
+    @Schema(description = "Marca de tiempo del mensaje", example = "2023-10-01")
+    private LocalDateTime timestamp;
+
+    @Schema(description = "Usuario que envió el mensaje", example = "Manolo")
+    private String sender;
+}

--- a/src/main/java/com/gamehub/dto/message/MessageCreatedDto.java
+++ b/src/main/java/com/gamehub/dto/message/MessageCreatedDto.java
@@ -1,0 +1,24 @@
+package com.gamehub.dto.message;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Schema(description = "DTO para la creación de un mensaje.")
+public class MessageCreatedDto {
+
+    @Schema(description = "Contenido del mensaje", example = "¡Hola a todos!")
+    private String content;
+
+    @Schema(description = "ID del usuario que envía el mensaje", example = "a1b2c3d4-e5f6-7890-1234-56789abcdef0")
+    private String sender;
+
+    @Schema(description = "ID del usuario que recibe el mensaje", example = "b1c2d3e4-f5g6-7890-1234-56789abcdef0")
+    private String match;
+
+    @Schema(description = "ID del torneo al que pertenece el mensaje", example = "c1d2e3f4-g5h6-7890-1234-56789abcdef0")
+    private String tournament;
+
+}

--- a/src/main/java/com/gamehub/dto/message/MessageDto.java
+++ b/src/main/java/com/gamehub/dto/message/MessageDto.java
@@ -1,6 +1,5 @@
-package com.gamehub.dto;
+package com.gamehub.dto.message;
 
-import com.gamehub.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import java.time.LocalDateTime;
@@ -12,9 +11,10 @@ public class MessageDto {
     @Schema(description = "Contenido del mensaje", example = "¡Hola, bienvenido a GameHub!")
     private String content;
 
-    @Schema(description = "Marca de tiempo del mensaje", example = "2023-10-01")
+    @Schema(description = "Fecha y hora del mensaje", example = "2025-06-23T15:45:00")
     private LocalDateTime timestamp;
 
-    @Schema(description = "Usuario que envió el mensaje", example = "Manolo")
+    @Schema(description = "Nombre del usuario que envió el mensaje", example = "Manolo")
     private String sender;
+
 }

--- a/src/main/java/com/gamehub/mapper/MessageMapper.java
+++ b/src/main/java/com/gamehub/mapper/MessageMapper.java
@@ -1,9 +1,15 @@
 package com.gamehub.mapper;
 
-import com.gamehub.dto.MessageDto;
+import com.gamehub.dto.message.MessageDto;
+import com.gamehub.model.Match;
 import com.gamehub.model.Message;
+import com.gamehub.model.Tournament;
+import com.gamehub.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -22,5 +28,20 @@ public class MessageMapper {
         dto.setTimestamp(message.getTimestamp());
 
         return dto;
+    }
+
+    public Message toEntity(MessageDto messageDto, User sender, Tournament tournament) {
+        if (messageDto == null) {
+            return null;
+        }
+
+        Message message = new Message();
+        message.setId(UUID.randomUUID());
+        message.setContent(messageDto.getContent());
+        message.setTimestamp(LocalDateTime.now());
+        message.setSender(sender);
+        message.setTournament(tournament);
+
+        return message;
     }
 }

--- a/src/main/java/com/gamehub/mapper/MessageMapper.java
+++ b/src/main/java/com/gamehub/mapper/MessageMapper.java
@@ -1,0 +1,26 @@
+package com.gamehub.mapper;
+
+import com.gamehub.dto.MessageDto;
+import com.gamehub.model.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MessageMapper {
+
+    private final UserMapper userMapper;
+
+    public MessageDto toDto(Message message) {
+        if (message == null) {
+            return null;
+        }
+
+        MessageDto dto = new MessageDto();
+        dto.setContent(message.getContent());
+        dto.setSender(message.getSender().getUsername());
+        dto.setTimestamp(message.getTimestamp());
+
+        return dto;
+    }
+}

--- a/src/main/java/com/gamehub/repository/MessageRepository.java
+++ b/src/main/java/com/gamehub/repository/MessageRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.List;
 
 public interface MessageRepository  extends JpaRepository<Message, UUID> {
 
+    List<Message> findByTournamentId(UUID tournamentId);
 }

--- a/src/main/java/com/gamehub/service/MessageService.java
+++ b/src/main/java/com/gamehub/service/MessageService.java
@@ -1,0 +1,11 @@
+package com.gamehub.service;
+
+import com.gamehub.dto.MessageDto;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MessageService {
+
+    List<MessageDto> findByTournamentIdMessages(UUID tournamentId);
+}

--- a/src/main/java/com/gamehub/service/MessageService.java
+++ b/src/main/java/com/gamehub/service/MessageService.java
@@ -1,6 +1,6 @@
 package com.gamehub.service;
 
-import com.gamehub.dto.MessageDto;
+import com.gamehub.dto.message.MessageDto;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,4 +8,6 @@ import java.util.UUID;
 public interface MessageService {
 
     List<MessageDto> findByTournamentIdMessages(UUID tournamentId);
+
+    MessageDto sendTournamentMessage(UUID tournamentId, MessageDto messageDto, UUID senderId);
 }

--- a/src/main/java/com/gamehub/service/MessageServiceImpl.java
+++ b/src/main/java/com/gamehub/service/MessageServiceImpl.java
@@ -1,7 +1,12 @@
 package com.gamehub.service;
 
-import com.gamehub.dto.MessageDto;
+import com.gamehub.dto.message.MessageDto;
+import com.gamehub.exception.TournamentNotFoundException;
+import com.gamehub.exception.UnauthorizedException;
 import com.gamehub.mapper.MessageMapper;
+import com.gamehub.model.Message;
+import com.gamehub.model.Tournament;
+import com.gamehub.model.User;
 import com.gamehub.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,11 +17,17 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class MessageServiceImpl implements MessageService{
+public class MessageServiceImpl implements MessageService {
 
     private final MessageRepository messageRepository;
 
     private final MessageMapper messageMapper;
+
+    private final TournamentService tournamentService;
+
+    private final UserService userService;
+
+    private final MatchService matchService;
 
     @Override
     public List<MessageDto> findByTournamentIdMessages(UUID tournamentId) {
@@ -24,5 +35,21 @@ public class MessageServiceImpl implements MessageService{
                 .stream()
                 .map(messageMapper::toDto)
                 .collect(Collectors.toList());
+    }
+
+    public MessageDto sendTournamentMessage(UUID tournamentId, MessageDto messageDto, UUID senderId) {
+
+        Tournament tournament = tournamentService.findById(tournamentId)
+                .orElseThrow(() -> new TournamentNotFoundException("Tournament not found"));
+
+        User sender = userService.findById(senderId)
+                .orElseThrow(() -> new UnauthorizedException("User not found"));
+
+        Message message = messageMapper.toEntity(messageDto, sender, tournament);
+
+        Message savedMessage = messageRepository.save(message);
+
+        return messageMapper.toDto(savedMessage);
+
     }
 }

--- a/src/main/java/com/gamehub/service/MessageServiceImpl.java
+++ b/src/main/java/com/gamehub/service/MessageServiceImpl.java
@@ -1,7 +1,28 @@
 package com.gamehub.service;
 
+import com.gamehub.dto.MessageDto;
+import com.gamehub.mapper.MessageMapper;
+import com.gamehub.repository.MessageRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 @Service
-public class MessageServiceImpl {
+@RequiredArgsConstructor
+public class MessageServiceImpl implements MessageService{
+
+    private final MessageRepository messageRepository;
+
+    private final MessageMapper messageMapper;
+
+    @Override
+    public List<MessageDto> findByTournamentIdMessages(UUID tournamentId) {
+        return messageRepository.findByTournamentId(tournamentId)
+                .stream()
+                .map(messageMapper::toDto)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/gamehub/service/TournamentService.java
+++ b/src/main/java/com/gamehub/service/TournamentService.java
@@ -3,8 +3,10 @@ package com.gamehub.service;
 import com.gamehub.dto.tournament.TournamentDto;
 import com.gamehub.dto.tournament.TournamentRequestDto;
 import com.gamehub.dto.tournament.TournamentResponseDto;
+import com.gamehub.model.Tournament;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface TournamentService {
@@ -16,4 +18,6 @@ public interface TournamentService {
     TournamentDto getTournamentById(UUID tournamentId);
 
     void joinTournament(UUID tournamentId, UUID userId);
+
+    Optional<Tournament> findById(UUID id);
 }

--- a/src/main/java/com/gamehub/service/TournamentServiceImpl.java
+++ b/src/main/java/com/gamehub/service/TournamentServiceImpl.java
@@ -86,4 +86,9 @@ public class TournamentServiceImpl implements TournamentService {
         tournamentRepository.save(tournament);
     }
 
+    @Override
+    public Optional<Tournament> findById(UUID id) {
+        return tournamentRepository.findById(id);
+    }
+
 }

--- a/src/main/java/com/gamehub/service/UserService.java
+++ b/src/main/java/com/gamehub/service/UserService.java
@@ -5,6 +5,7 @@ import com.gamehub.dto.UserDto;
 import com.gamehub.dto.UserPublicDto;
 import com.gamehub.model.User;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserService {
@@ -14,5 +15,7 @@ public interface UserService {
     UserPublicDto getUserById(UUID userId);
 
     User getCurrentUserEntity();
+
+    Optional<User> findById(UUID userId);
 
 }


### PR DESCRIPTION
**Descripción del Pull Request: Chat en Torneos**
Este PR agrega la funcionalidad de envío y visualización de mensajes dentro del contexto de un torneo. Incluye:

- Endpoint GET /tournaments/{id}/messages para listar mensajes de un torneo (PLAYER, ADMIN)

- Endpoint POST /tournaments/{id}/messages para enviar un mensaje al torneo (PLAYER, ADMIN)

- DTO (MessageDto), mapper (MessageMapper) y ajustes en el modelo Message

- Servicios y controladores para el manejo de mensajes

- Documentación Swagger para los nuevos endpoints